### PR TITLE
Escape character should be taken into account when parsing the type literal

### DIFF
--- a/api/src/main/java/org/hawkular/inventory/api/model/Path.java
+++ b/api/src/main/java/org/hawkular/inventory/api/model/Path.java
@@ -477,6 +477,7 @@ public abstract class Path {
             //1 = reading id
             //2 = reading escape char
             int state = 0;
+            int stateBeforeEscapeChar = -1;
 
             loop:
             while (!progress.isFinished()) {
@@ -499,6 +500,10 @@ public abstract class Path {
                                 currentTypeString = currentId.toString();
                                 currentId.delete(0, currentId.length());
                                 break loop;
+                            case ESCAPE_CHAR:
+                                state = 2; // reading escape char
+                                stateBeforeEscapeChar = 0;
+                                break;
                             default:
                                 currentId.append(c);
                         }
@@ -507,6 +512,7 @@ public abstract class Path {
                         switch (c) {
                             case ESCAPE_CHAR:
                                 state = 2; // reading escape char
+                                stateBeforeEscapeChar = 1;
                                 break;
                             case PATH_DELIM:
                                 if (currentId.length() == 0) {
@@ -521,7 +527,8 @@ public abstract class Path {
                         break;
                     case 2: //reading escape char
                         currentId.append(c);
-                        state = 1;
+                        state = stateBeforeEscapeChar;
+                        stateBeforeEscapeChar = -1;
                         break;
                 }
             }


### PR DESCRIPTION
I fixed the tests, too, to check for correct things.

When constructing the path using the API, i.e. adding segments one by one, the ids are taken as they are. It is only when serializing the path to string or deserializing from string where the escaping needs
to happen.

I.e. in case of the agent using slashes in its ids - those IDs should be passed to the path creating methods without any massaging. The path (de)serialization over the wire should take care of proper escaping.
